### PR TITLE
Fix for issue xrr2016/tata#6

### DIFF
--- a/src/tata.js
+++ b/src/tata.js
@@ -182,7 +182,7 @@ function render(title, text, opts) {
     progress.style.animation = `${opts.duration / 1000}s reduceWidth linear forwards`
 
     const vanish = setTimeout(() => {
-      const idx = tatas.findIndex(ta => ta === ta)
+      const idx = tatas.findIndex(t => t.id === ta.id)
       tatas.splice(idx, 1)
       element.classList.add(mapAnimateOut(ta.opts.animate, ta.opts.position))
       console.log(performance.now())


### PR DESCRIPTION
Root cause: When a toast is being removed say due to timeout we try to find it in the list of toasts stored in tatas list.
The logic for finding the outgoing toast was flawed, and instead of removing an outgoing toast we were always removing the
very first toast in the list. The current check "ta => ta === ta" is a tautology ie. it will be true for all elements of the list.
Thus we always end up removing the first element.
Now consider the following scenario.
1. User shows toast A with holding on
2. User then shows toast B with 5s timeout
3. Now when B times out, instead of removing B from tatas list we remove A since A is the first element of the list
4. Now when user clicks on close button of toast A, we try to find A in tatas list so as to decide what action has to be done, and to fire callbacks if any.
Since infor for toast A has already been removed we are unable to find anything and code execution fails. No action is taken, and the toast remains open.
Fix: The fix makes sure we remove the correct toast from list by comparing id.